### PR TITLE
Avoid writing uninitialized stack memory into INFO.ind and LEARN.ind

### DIFF
--- a/LiE/util/infoind.c
+++ b/LiE/util/infoind.c
@@ -70,6 +70,7 @@ int main(void)
   FILE *indexpt,*infopt;
   info_index_tp info; /* current info record */
 
+  memset(&info, 0, sizeof(info));
   strcpy(indexfil,INDEXFIL);
   indexpt=fopen(indexfil,writemode);
   if (indexpt==NULL)

--- a/LiE/util/learnind.c
+++ b/LiE/util/learnind.c
@@ -24,6 +24,7 @@ int main(void)
   FILE *indexpt,*learnpt;
   learn_index_tp learn;
 
+  memset(&learn, 0, sizeof(learn));
   strcpy(indexfil,INDEXFIL); strcpy(learnfil,LEARNFIL);
   learnpt=fopen(learnfil,readmode);
   if (learnpt==NULL)


### PR DESCRIPTION
(probably required because compilers do padding on structs)
in order to make package builds reproducible
See https://reproducible-builds.org/ for why this is good

I could not find a way to contribute this patch to upstream LiE,
so I'm sending it here in the hope that it will be useful
and eventually find its way to upstream.

Also tracked at https://bugzilla.opensuse.org/show_bug.cgi?id=1061220